### PR TITLE
Add NonPersistent attribute

### DIFF
--- a/Tutorials/WPF/Classic/CS/DataAccess/BaseObject.cs
+++ b/Tutorials/WPF/Classic/CS/DataAccess/BaseObject.cs
@@ -2,6 +2,7 @@
 
 namespace XpoTutorial {
 
+    [NonPersistent]
     [DeferredDeletion]
     [OptimisticLocking]
     public class BaseObject : PersistentBase {

--- a/Tutorials/WPF/Classic/VB/DataAccess/BaseObject.vb
+++ b/Tutorials/WPF/Classic/VB/DataAccess/BaseObject.vb
@@ -2,6 +2,7 @@
 
 Namespace XpoTutorial
 
+	<NonPersistent> _
 	<DeferredDeletion, OptimisticLocking>
 	Public Class BaseObject
 		Inherits PersistentBase


### PR DESCRIPTION
You don't want to have a large BaseObject table containing only identifiers. Make the base class non-persistent.