### PR TITLE
Consistent property implementation

### DIFF
--- a/Tutorials/WPF/Classic/CS/DataAccess/BaseObject.cs
+++ b/Tutorials/WPF/Classic/CS/DataAccess/BaseObject.cs
@@ -7,10 +7,11 @@ namespace XpoTutorial {
     public class BaseObject : PersistentBase {
         public BaseObject(Session session) : base(session) { }
 
+        int oid;
         [Key(true)]
         public int Oid {
-            get { return GetPropertyValue<int>(nameof(Oid)); }
-            set { SetPropertyValue(nameof(Oid), value); }
+            get { oid; }
+            set { SetPropertyValue(nameof(Oid), ref oid, value); }
         }
     }
 }

--- a/Tutorials/WPF/Classic/CS/DataAccess/Customer.cs
+++ b/Tutorials/WPF/Classic/CS/DataAccess/Customer.cs
@@ -8,13 +8,15 @@ namespace XpoTutorial {
 
     public class Customer : BaseObject {
         public Customer(Session session) : base(session) { }
+        string firstName;
         public string FirstName {
-            get { return GetPropertyValue<string>(nameof(FirstName)); }
-            set { SetPropertyValue(nameof(FirstName), value); }
+            get { return firstName; }
+            set { SetPropertyValue(nameof(FirstName), ref firstName, value); }
         }
+        string lastName;
         public string LastName {
-            get { return GetPropertyValue<string>(nameof(LastName)); }
-            set { SetPropertyValue(nameof(LastName), value); }
+            get { return lastName; }
+            set { SetPropertyValue(nameof(LastName), ref lastName, value); }
         }
         [NonPersistent]
         public string ContactName {

--- a/Tutorials/WPF/Classic/CS/DataAccess/Order.cs
+++ b/Tutorials/WPF/Classic/CS/DataAccess/Order.cs
@@ -12,18 +12,21 @@ namespace XpoTutorial {
             get { return productName; }
             set { SetPropertyValue(nameof(ProductName), ref productName, value); }
         }
+        DateTime orderDate;
         public DateTime OrderDate {
-            get { return GetPropertyValue<DateTime>(nameof(OrderDate)); }
-            set { SetPropertyValue(nameof(OrderDate), value); }
+            get { return orderDate; }
+            set { SetPropertyValue(nameof(OrderDate), ref orderDate, value); }
         }
+        decimal? freight;
         public decimal? Freight {
-            get { return GetPropertyValue<decimal?>(nameof(Freight)); }
-            set { SetPropertyValue(nameof(Freight), value); }
+            get { return freight; }
+            set { SetPropertyValue(nameof(Freight), ref freight, value); }
         }
+        Customer customer;
         [Association("CustomerOrders")]
         public Customer Customer {
-            get { return GetPropertyValue<Customer>(nameof(Customer)); }
-            set { SetPropertyValue(nameof(Customer), value); }
+            get { return customer; }
+            set { SetPropertyValue(nameof(Customer), ref customer, value); }
         }
 
         #region IEditableObject implementation

--- a/Tutorials/WPF/Classic/VB/DataAccess/BaseObject.vb
+++ b/Tutorials/WPF/Classic/VB/DataAccess/BaseObject.vb
@@ -10,13 +10,14 @@ Namespace XpoTutorial
 			MyBase.New(session)
 		End Sub
 
+		Private fOid As Integer
 		<Key(True)>
 		Public Property Oid() As Integer
 			Get
-				Return GetPropertyValue(Of Integer)(NameOf(Oid))
+				Return fOid
 			End Get
 			Set(ByVal value As Integer)
-				SetPropertyValue(NameOf(Oid), value)
+				SetPropertyValue(NameOf(Oid), fOid, value)
 			End Set
 		End Property
 	End Class

--- a/Tutorials/WPF/Classic/VB/DataAccess/Customer.vb
+++ b/Tutorials/WPF/Classic/VB/DataAccess/Customer.vb
@@ -12,20 +12,22 @@ Namespace XpoTutorial
 		Public Sub New(ByVal session As Session)
 			MyBase.New(session)
 		End Sub
+		Private fFirstName As String
 		Public Property FirstName() As String
 			Get
-				Return GetPropertyValue(Of String)(NameOf(FirstName))
+				Return fFirstName
 			End Get
 			Set(ByVal value As String)
-				SetPropertyValue(NameOf(FirstName), value)
+				SetPropertyValue(NameOf(FirstName), fFirstName, value)
 			End Set
 		End Property
+		Private fLastName As String
 		Public Property LastName() As String
 			Get
-				Return GetPropertyValue(Of String)(NameOf(LastName))
+				Return fLastName
 			End Get
 			Set(ByVal value As String)
-				SetPropertyValue(NameOf(LastName), value)
+				SetPropertyValue(NameOf(LastName), fLastName, value)
 			End Set
 		End Property
 		<NonPersistent>

--- a/Tutorials/WPF/Classic/VB/DataAccess/Order.vb
+++ b/Tutorials/WPF/Classic/VB/DataAccess/Order.vb
@@ -12,39 +12,41 @@ Namespace XpoTutorial
 		Public Sub New(ByVal session As Session)
 			MyBase.New(session)
 		End Sub
-'INSTANT VB NOTE: The field productName was renamed since Visual Basic does not allow fields to have the same name as other class members:
-		Private productName_Renamed As String
+		Private fProductName As String
 		Public Property ProductName() As String
 			Get
-				Return productName_Renamed
+				Return fProductName
 			End Get
 			Set(ByVal value As String)
-				SetPropertyValue(NameOf(ProductName), productName_Renamed, value)
+				SetPropertyValue(NameOf(ProductName), fProductName, value)
 			End Set
 		End Property
+		Private fOrderDate As Date
 		Public Property OrderDate() As Date
 			Get
-				Return GetPropertyValue(Of Date)(NameOf(OrderDate))
+				Return fOrderDate
 			End Get
 			Set(ByVal value As Date)
-				SetPropertyValue(NameOf(OrderDate), value)
+				SetPropertyValue(NameOf(OrderDate), fOrderDate, value)
 			End Set
 		End Property
+		Private fFreight Decimal
 		Public Property Freight() As Decimal?
 			Get
-				Return GetPropertyValue(Of Decimal?)(NameOf(Freight))
+				Return fFreight
 			End Get
 			Set(ByVal value? As Decimal)
-				SetPropertyValue(NameOf(Freight), value)
+				SetPropertyValue(NameOf(Freight), fFreight, value)
 			End Set
 		End Property
+		Private fCustomer As Customer
 		<Association("CustomerOrders")>
 		Public Property Customer() As Customer
 			Get
-				Return GetPropertyValue(Of Customer)(NameOf(Customer))
+				Return fCustomer
 			End Get
 			Set(ByVal value As Customer)
-				SetPropertyValue(NameOf(Customer), value)
+				SetPropertyValue(NameOf(Customer), fCustomer, value)
 			End Set
 		End Property
 


### PR DESCRIPTION
Use either backing field or `GetPropertyValue` everywhere. The former is preferable. It is faster than the latter for client-side sorting/filtering with large collections.