### PR TITLE
Backing field naming convention - use prefixes

### DIFF
--- a/Tutorials/WPF/Classic/CS/Wrappers/CustomerEditWrapper.cs
+++ b/Tutorials/WPF/Classic/CS/Wrappers/CustomerEditWrapper.cs
@@ -22,48 +22,48 @@ namespace WpfApplication.Wrappers {
             Customer = unitOfWork.GetObjectByKey<Customer>(customerOid);
         }
 
-        Customer customer;
+        Customer fCustomer;
         public Customer Customer {
             get {
-                return customer;
+                return fCustomer;
             }
             set {
-                customer = value;
-                OrderList = customer.Orders;
+                fCustomer = value;
+                OrderList = fCustomer.Orders;
                 OnPropertyChanged(nameof(Customer));
             }
         }
 
-        IList<Order> orderList;
+        IList<Order> fOrderList;
         public IList<Order> OrderList {
             get {
-                return orderList;
+                return fOrderList;
             }
             set {
-                orderList = value;
+                fOrderList = value;
                 OnPropertyChanged(nameof(OrderList));
             }
         }
 
-        Order selectedOrder;
+        Order fSelectedOrder;
         public Order SelectedOrder {
             get {
-                return selectedOrder;
+                return fSelectedOrder;
             }
             set {
-                selectedOrder = value;
+                fSelectedOrder = value;
                 IsOrderSelected = (value != null);
                 OnPropertyChanged(nameof(SelectedOrder));
             }
         }
 
-        bool isOrderSelected;
+        bool fIsOrderSelected;
         public bool IsOrderSelected {
             get {
-                return isOrderSelected;
+                return fIsOrderSelected;
             }
             set {
-                isOrderSelected = value;
+                fIsOrderSelected = value;
                 OnPropertyChanged(nameof(IsOrderSelected));
             }
         }

--- a/Tutorials/WPF/Classic/CS/Wrappers/CustomerListWrapper.cs
+++ b/Tutorials/WPF/Classic/CS/Wrappers/CustomerListWrapper.cs
@@ -37,36 +37,36 @@ namespace WpfApplication.Wrappers {
             }
         }
 
-        ObservableCollection<Customer> customerList;
+        ObservableCollection<Customer> fCustomerList;
         public ObservableCollection<Customer> CustomerList {
             get {
-                return customerList;
+                return fCustomerList;
             }
             set {
-                customerList = value;
+                fCustomerList = value;
                 OnPropertyChanged(nameof(CustomerList));
             }
         }
 
-        Customer selectedCustomer;
+        Customer fSelectedCustomer;
         public Customer SelectedCustomer {
             get {
-                return selectedCustomer;
+                return fSelectedCustomer;
             }
             set {
-                selectedCustomer = value;
+                fSelectedCustomer = value;
                 IsCustomerSelected = (value != null);
                 OnPropertyChanged(nameof(SelectedCustomer));
             }
         }
 
-        bool isCustomerSelected;
+        bool fIsCustomerSelected;
         public bool IsCustomerSelected {
             get {
-                return isCustomerSelected;
+                return fIsCustomerSelected;
             }
             set {
-                isCustomerSelected = value;
+                fIsCustomerSelected = value;
                 OnPropertyChanged(nameof(IsCustomerSelected));
             }
         }

--- a/Tutorials/WPF/Classic/CS/Wrappers/OrderEditWrapper.cs
+++ b/Tutorials/WPF/Classic/CS/Wrappers/OrderEditWrapper.cs
@@ -13,38 +13,38 @@ namespace WpfApplication.Wrappers {
             ((IEditableObject)order).BeginEdit();
         }
 
-        Order order;
+        Order fOrder;
         public Order Order {
             get {
-                return order;
+                return fOrder;
             }
             set {
-                order = value;
+                fOrder = value;
                 OnPropertyChanged(nameof(Customer));
             }
         }
 
         public IList<Customer> CustomerList {
             get {
-                var customers = order.Session.Query<Customer>().OrderBy(t => t.FirstName).ThenBy(t => t.LastName).ToList();
-                if(!customers.Contains(order.Customer)) {
-                    customers.Add(order.Customer);
+                var customers = Order.Session.Query<Customer>().OrderBy(t => t.FirstName).ThenBy(t => t.LastName).ToList();
+                if(!customers.Contains(Order.Customer)) {
+                    customers.Add(Order.Customer);
                 }
                 return customers;
             }
         }
 
         public void Reload() {
-            ((IEditableObject)order).CancelEdit();
-            ((IEditableObject)order).BeginEdit();
+            ((IEditableObject)Order).CancelEdit();
+            ((IEditableObject)Order).BeginEdit();
         }
 
         public void EndEdit() {
-            ((IEditableObject)order).EndEdit();
+            ((IEditableObject)Order).EndEdit();
         }
 
         public void CancelEdit() {
-            ((IEditableObject)order).CancelEdit();
+            ((IEditableObject)Order).CancelEdit();
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/Tutorials/WPF/Classic/VB/Wrappers/CustomerEditWrapper.vb
+++ b/Tutorials/WPF/Classic/VB/Wrappers/CustomerEditWrapper.vb
@@ -24,52 +24,48 @@ Namespace WpfApplication.Wrappers
 			Customer = unitOfWork.GetObjectByKey(Of Customer)(customerOid)
 		End Sub
 
-'INSTANT VB NOTE: The field customer was renamed since Visual Basic does not allow fields to have the same name as other class members:
-		Private customer_Renamed As Customer
+		Private fCustomer As Customer
 		Public Property Customer() As Customer
 			Get
-				Return customer_Renamed
+				Return fCustomer
 			End Get
 			Set(ByVal value As Customer)
-				customer_Renamed = value
-				OrderList = customer_Renamed.Orders
+				fCustomer = value
+				OrderList = fCustomer.Orders
 				OnPropertyChanged(NameOf(Customer))
 			End Set
 		End Property
 
-'INSTANT VB NOTE: The field orderList was renamed since Visual Basic does not allow fields to have the same name as other class members:
-		Private orderList_Renamed As IList(Of Order)
+		Private fOrderList As IList(Of Order)
 		Public Property OrderList() As IList(Of Order)
 			Get
-				Return orderList_Renamed
+				Return fOrderList
 			End Get
 			Set(ByVal value As IList(Of Order))
-				orderList_Renamed = value
+				fOrderList = value
 				OnPropertyChanged(NameOf(OrderList))
 			End Set
 		End Property
 
-'INSTANT VB NOTE: The field selectedOrder was renamed since Visual Basic does not allow fields to have the same name as other class members:
-		Private selectedOrder_Renamed As Order
+		Private fSelectedOrder As Order
 		Public Property SelectedOrder() As Order
 			Get
-				Return selectedOrder_Renamed
+				Return fSelectedOrder
 			End Get
 			Set(ByVal value As Order)
-				selectedOrder_Renamed = value
+				fSelectedOrder = value
 				IsOrderSelected = (value IsNot Nothing)
 				OnPropertyChanged(NameOf(SelectedOrder))
 			End Set
 		End Property
 
-'INSTANT VB NOTE: The field isOrderSelected was renamed since Visual Basic does not allow fields to have the same name as other class members:
-		Private isOrderSelected_Renamed As Boolean
+		Private fIsOrderSelected As Boolean
 		Public Property IsOrderSelected() As Boolean
 			Get
-				Return isOrderSelected_Renamed
+				Return fIsOrderSelected
 			End Get
 			Set(ByVal value As Boolean)
-				isOrderSelected_Renamed = value
+				fIsOrderSelected = value
 				OnPropertyChanged(NameOf(IsOrderSelected))
 			End Set
 		End Property

--- a/Tutorials/WPF/Classic/VB/Wrappers/CustomerListWrapper.vb
+++ b/Tutorials/WPF/Classic/VB/Wrappers/CustomerListWrapper.vb
@@ -38,39 +38,36 @@ Namespace WpfApplication.Wrappers
 			End If
 		End Function
 
-'INSTANT VB NOTE: The field customerList was renamed since Visual Basic does not allow fields to have the same name as other class members:
-		Private customerList_Renamed As ObservableCollection(Of Customer)
+		Private fCustomerList As ObservableCollection(Of Customer)
 		Public Property CustomerList() As ObservableCollection(Of Customer)
 			Get
-				Return customerList_Renamed
+				Return fCustomerList
 			End Get
 			Set(ByVal value As ObservableCollection(Of Customer))
-				customerList_Renamed = value
+				fCustomerList = value
 				OnPropertyChanged(NameOf(CustomerList))
 			End Set
 		End Property
 
-'INSTANT VB NOTE: The field selectedCustomer was renamed since Visual Basic does not allow fields to have the same name as other class members:
-		Private selectedCustomer_Renamed As Customer
+		Private fSelectedCustomer As Customer
 		Public Property SelectedCustomer() As Customer
 			Get
-				Return selectedCustomer_Renamed
+				Return fSelectedCustomer
 			End Get
 			Set(ByVal value As Customer)
-				selectedCustomer_Renamed = value
+				fSelectedCustomer = value
 				IsCustomerSelected = (value IsNot Nothing)
 				OnPropertyChanged(NameOf(SelectedCustomer))
 			End Set
 		End Property
 
-'INSTANT VB NOTE: The field isCustomerSelected was renamed since Visual Basic does not allow fields to have the same name as other class members:
-		Private isCustomerSelected_Renamed As Boolean
+		Private fIsCustomerSelected As Boolean
 		Public Property IsCustomerSelected() As Boolean
 			Get
-				Return isCustomerSelected_Renamed
+				Return fIsCustomerSelected
 			End Get
 			Set(ByVal value As Boolean)
-				isCustomerSelected_Renamed = value
+				fIsCustomerSelected = value
 				OnPropertyChanged(NameOf(IsCustomerSelected))
 			End Set
 		End Property

--- a/Tutorials/WPF/Classic/VB/Wrappers/OrderEditWrapper.vb
+++ b/Tutorials/WPF/Classic/VB/Wrappers/OrderEditWrapper.vb
@@ -15,39 +15,38 @@ Namespace WpfApplication.Wrappers
 			DirectCast(order, IEditableObject).BeginEdit()
 		End Sub
 
-'INSTANT VB NOTE: The field order was renamed since Visual Basic does not allow fields to have the same name as other class members:
-		Private order_Renamed As Order
+		Private fOrder As Order
 		Public Property Order() As Order
 			Get
-				Return order_Renamed
+				Return fOrder
 			End Get
 			Set(ByVal value As Order)
-				order_Renamed = value
+				fOrder = value
 				OnPropertyChanged(NameOf(Customer))
 			End Set
 		End Property
 
 		Public ReadOnly Property CustomerList() As IList(Of Customer)
 			Get
-				Dim customers = order_Renamed.Session.Query(Of Customer)().OrderBy(Function(t) t.FirstName).ThenBy(Function(t) t.LastName).ToList()
-				If Not customers.Contains(order_Renamed.Customer) Then
-					customers.Add(order_Renamed.Customer)
+				Dim customers = Order.Session.Query(Of Customer)().OrderBy(Function(t) t.FirstName).ThenBy(Function(t) t.LastName).ToList()
+				If Not customers.Contains(Order.Customer) Then
+					customers.Add(Order.Customer)
 				End If
 				Return customers
 			End Get
 		End Property
 
 		Public Sub Reload()
-			DirectCast(order_Renamed, IEditableObject).CancelEdit()
-			DirectCast(order_Renamed, IEditableObject).BeginEdit()
+			DirectCast(Order, IEditableObject).CancelEdit()
+			DirectCast(Order, IEditableObject).BeginEdit()
 		End Sub
 
 		Public Sub EndEdit()
-			DirectCast(order_Renamed, IEditableObject).EndEdit()
+			DirectCast(Order, IEditableObject).EndEdit()
 		End Sub
 
 		Public Sub CancelEdit()
-			DirectCast(order_Renamed, IEditableObject).CancelEdit()
+			DirectCast(Order, IEditableObject).CancelEdit()
 		End Sub
 
 		Public Event PropertyChanged As PropertyChangedEventHandler Implements INotifyPropertyChanged.PropertyChanged


### PR DESCRIPTION
Do no use lower case to distinguish between a property name and a backing field name. This code won't work in VB.NET, because it is case-insensitive. Use a prefix, instead. The "f" prefix is common in DevExpress for backing field names.