### PR TITLE
Use the database server term

### DIFF
--- a/Tutorials/ASP.NET/Blazor.ServerSide/CS/Startup.cs
+++ b/Tutorials/ASP.NET/Blazor.ServerSide/CS/Startup.cs
@@ -34,7 +34,7 @@ namespace BlazorServerSideApplication {
             services.AddXpoDefaultUnitOfWork(true, options => options
                     .UseConnectionString(Configuration.GetConnectionString("ImMemoryDataStore"))
                     .UseThreadSafeDataLayer(true)
-                    .UseConnectionPool(false) // Remove this line if you use a network database like SQL Server, Oracle, PostgreSql etc.                    
+                    .UseConnectionPool(false) // Remove this line if you use a database server like SQL Server, Oracle, PostgreSql etc.                    
                     .UseAutoCreationOption(DevExpress.Xpo.DB.AutoCreateOption.DatabaseAndSchema) // Remove this line if the database already exists
                     .UseEntityTypes(typeof(Customer), typeof(Order)) // Pass all of your persistent object types to this method.
             );

--- a/Tutorials/ASP.NET/MVC.Core/CS/Startup.cs
+++ b/Tutorials/ASP.NET/MVC.Core/CS/Startup.cs
@@ -23,7 +23,7 @@ namespace AspNetCoreMvcApplication {
                 .AddXpoDefaultUnitOfWork(true, options => options
                     .UseConnectionString(Configuration.GetConnectionString("ImMemoryDataStore"))
                     .UseThreadSafeDataLayer(true)
-                    .UseConnectionPool(false) // Remove this line if you use a network database like SQL Server, Oracle, PostgreSql etc.                    
+                    .UseConnectionPool(false) // Remove this line if you use a database server like SQL Server, Oracle, PostgreSql etc.                    
                     .UseAutoCreationOption(DevExpress.Xpo.DB.AutoCreateOption.DatabaseAndSchema) // Remove this line if the database already exists
                     .UseEntityTypes(typeof(Customer), typeof(Order)) // Pass all of your persistent object types to this method.
                 );

--- a/Tutorials/ASP.NET/MVC.RazorPages/CS/Startup.cs
+++ b/Tutorials/ASP.NET/MVC.RazorPages/CS/Startup.cs
@@ -21,7 +21,7 @@ namespace AspNetCoreRazorPagesApplication {
                 .AddXpoDefaultUnitOfWork(true, options => options
                     .UseConnectionString(Configuration.GetConnectionString("ImMemoryDataStore"))
                     .UseThreadSafeDataLayer(true)
-                    .UseConnectionPool(false) // Remove this line if you use a network database like Sql Server, Oracle, PostgreSql etc.                    
+                    .UseConnectionPool(false) // Remove this line if you use a database server like Sql Server, Oracle, PostgreSql etc.                    
                     .UseAutoCreationOption(DevExpress.Xpo.DB.AutoCreateOption.DatabaseAndSchema) // Remove this line if the database already exists
                     .UseEntityTypes(typeof(Customer), typeof(Order)) // Pass all of your persistent object types to this method.
                 );

--- a/Tutorials/WPF/Classic/CS/DataAccess/ConnectionHelper.cs
+++ b/Tutorials/WPF/Classic/CS/DataAccess/ConnectionHelper.cs
@@ -18,7 +18,7 @@ namespace XpoTutorial {
 
         static IDataLayer CreateDataLayer(bool threadSafe) {
             string connStr = ConfigurationManager.ConnectionStrings["XpoTutorial"].ConnectionString;
-            //connStr = XpoDefault.GetConnectionPoolString(connStr);  // Uncomment this line if you use a network database like SQL Server, Oracle, PostgreSql etc.
+            //connStr = XpoDefault.GetConnectionPoolString(connStr);  // Uncomment this line if you use a database server like SQL Server, Oracle, PostgreSql etc.
             ReflectionDictionary dictionary = new ReflectionDictionary();
             dictionary.GetDataStoreSchema(PersistentTypes);   // Pass all of your persistent object types to this method.
             AutoCreateOption autoCreateOption = AutoCreateOption.DatabaseAndSchema;  // Use AutoCreateOption.DatabaseAndSchema if the database or tables does not exists. Use AutoCreateOption.SchemaAlreadyExists if the database already exists.

--- a/Tutorials/WPF/Classic/VB/DataAccess/ConnectionHelper.vb
+++ b/Tutorials/WPF/Classic/VB/DataAccess/ConnectionHelper.vb
@@ -15,7 +15,7 @@ Namespace XpoTutorial
 
 		Private Function CreateDataLayer(ByVal threadSafe As Boolean) As IDataLayer
 			Dim connStr As String = ConfigurationManager.ConnectionStrings("XpoTutorial").ConnectionString
-			'connStr = XpoDefault.GetConnectionPoolString(connStr);  // Uncomment this line if you use a network database like SQL Server, Oracle, PostgreSql etc.
+			'connStr = XpoDefault.GetConnectionPoolString(connStr);  // Uncomment this line if you use a database server like SQL Server, Oracle, PostgreSql etc.
 			Dim dictionary As New ReflectionDictionary()
 			dictionary.GetDataStoreSchema(PersistentTypes) ' Pass all of your persistent object types to this method.
 			Dim autoCreateOption As AutoCreateOption = DevExpress.Xpo.DB.AutoCreateOption.DatabaseAndSchema ' Use AutoCreateOption.DatabaseAndSchema if the database or tables does not exists. Use AutoCreateOption.SchemaAlreadyExists if the database already exists.

--- a/Tutorials/WinForms/Classic/CS/DataAccess/ConnectionHelper.cs
+++ b/Tutorials/WinForms/Classic/CS/DataAccess/ConnectionHelper.cs
@@ -18,7 +18,7 @@ namespace XpoTutorial {
 
         static IDataLayer CreateDataLayer(bool threadSafe) {
             string connStr = ConfigurationManager.ConnectionStrings["XpoTutorial"].ConnectionString;
-            //connStr = XpoDefault.GetConnectionPoolString(connStr);  // Uncomment this line if you use a network database like SQL Server, Oracle, PostgreSql etc.
+            //connStr = XpoDefault.GetConnectionPoolString(connStr);  // Uncomment this line if you use a database server like SQL Server, Oracle, PostgreSql etc.
             ReflectionDictionary dictionary = new ReflectionDictionary();
             dictionary.GetDataStoreSchema(PersistentTypes);   // Pass all of your persistent object types to this method.
             AutoCreateOption autoCreateOption = AutoCreateOption.DatabaseAndSchema;  // Use AutoCreateOption.DatabaseAndSchema if the database or tables does not exists. Use AutoCreateOption.SchemaAlreadyExists if the database already exists.

--- a/Tutorials/WinForms/Classic/VB/DataAccess/ConnectionHelper.vb
+++ b/Tutorials/WinForms/Classic/VB/DataAccess/ConnectionHelper.vb
@@ -15,7 +15,7 @@ Namespace XpoTutorial
 
 		Private Function CreateDataLayer(ByVal threadSafe As Boolean) As IDataLayer
 			Dim connStr As String = ConfigurationManager.ConnectionStrings("XpoTutorial").ConnectionString
-			'connStr = XpoDefault.GetConnectionPoolString(connStr);  // Uncomment this line if you use a network database like SQL Server, Oracle, PostgreSql etc.
+			'connStr = XpoDefault.GetConnectionPoolString(connStr);  // Uncomment this line if you use a database server like SQL Server, Oracle, PostgreSql etc.
 			Dim dictionary As New ReflectionDictionary()
 			dictionary.GetDataStoreSchema(PersistentTypes) ' Pass all of your persistent object types to this method.
 			Dim autoCreateOption As AutoCreateOption = DevExpress.Xpo.DB.AutoCreateOption.DatabaseAndSchema ' Use AutoCreateOption.DatabaseAndSchema if the database or tables does not exists. Use AutoCreateOption.SchemaAlreadyExists if the database already exists.


### PR DESCRIPTION
We came to the agreement to use the "database server" term instead of "network database' everywhere in comments and readmies. Search for the corresponding conversation in Teams using above keywords.