### PR TITLE
Changed class modifiers

### DIFF
--- a/Tutorials/WPF/Classic/CS/Wrappers/CustomerEditWrapper.cs
+++ b/Tutorials/WPF/Classic/CS/Wrappers/CustomerEditWrapper.cs
@@ -7,7 +7,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Generic;
 
 namespace WpfApplication.Wrappers {
-    class CustomerEditWrapper : INotifyPropertyChanged {
+    public class CustomerEditWrapper : INotifyPropertyChanged {
         UnitOfWork unitOfWork;
         readonly int? customerOid;
 

--- a/Tutorials/WPF/Classic/CS/Wrappers/CustomerListWrapper.cs
+++ b/Tutorials/WPF/Classic/CS/Wrappers/CustomerListWrapper.cs
@@ -9,7 +9,7 @@ using System.Collections.ObjectModel;
 
 namespace WpfApplication.Wrappers {
 
-    class CustomerListWrapper : INotifyPropertyChanged {
+    public class CustomerListWrapper : INotifyPropertyChanged {
 
         UnitOfWork unitOfWork;
 

--- a/Tutorials/WPF/Classic/CS/Wrappers/OrderEditWrapper.cs
+++ b/Tutorials/WPF/Classic/CS/Wrappers/OrderEditWrapper.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace WpfApplication.Wrappers {
 
-    class OrderEditWrapper : INotifyPropertyChanged {
+    pubilc class OrderEditWrapper : INotifyPropertyChanged {
         public OrderEditWrapper(Order order) {
             Order = order;
             ((IEditableObject)order).BeginEdit();

--- a/Tutorials/WPF/Classic/VB/Wrappers/CustomerEditWrapper.vb
+++ b/Tutorials/WPF/Classic/VB/Wrappers/CustomerEditWrapper.vb
@@ -7,7 +7,7 @@ Imports System.Collections.ObjectModel
 Imports System.Collections.Generic
 
 Namespace WpfApplication.Wrappers
-	Friend Class CustomerEditWrapper
+	Public Class CustomerEditWrapper
 		Implements INotifyPropertyChanged
 
 		Private unitOfWork As UnitOfWork

--- a/Tutorials/WPF/Classic/VB/Wrappers/CustomerListWrapper.vb
+++ b/Tutorials/WPF/Classic/VB/Wrappers/CustomerListWrapper.vb
@@ -9,7 +9,7 @@ Imports System.Collections.ObjectModel
 
 Namespace WpfApplication.Wrappers
 
-	Friend Class CustomerListWrapper
+	Public Class CustomerListWrapper
 		Implements INotifyPropertyChanged
 
 		Private unitOfWork As UnitOfWork

--- a/Tutorials/WPF/Classic/VB/Wrappers/OrderEditWrapper.vb
+++ b/Tutorials/WPF/Classic/VB/Wrappers/OrderEditWrapper.vb
@@ -7,7 +7,7 @@ Imports System.Linq
 
 Namespace WpfApplication.Wrappers
 
-	Friend Class OrderEditWrapper
+	Public Class OrderEditWrapper
 		Implements INotifyPropertyChanged
 
 		Public Sub New(ByVal order As Order)


### PR DESCRIPTION
There is no need to make classes private (Friend in Visual Basic). I suspect that the modifier was left unassigned in error.