### PR TITLE
Use PersistentAlias attribute

### DIFF
--- a/Tutorials/WPF/Classic/CS/DataAccess/Customer.cs
+++ b/Tutorials/WPF/Classic/CS/DataAccess/Customer.cs
@@ -16,7 +16,7 @@ namespace XpoTutorial {
             get { return GetPropertyValue<string>(nameof(LastName)); }
             set { SetPropertyValue(nameof(LastName), value); }
         }
-        [NonPersistent]
+        [PersistentAlias("Concat(FirstName, ' ', LastName)")]
         public string ContactName {
             get { return string.Concat(FirstName, " ", LastName); }
         }

--- a/Tutorials/WPF/Classic/VB/DataAccess/Customer.vb
+++ b/Tutorials/WPF/Classic/VB/DataAccess/Customer.vb
@@ -28,7 +28,7 @@ Namespace XpoTutorial
 				SetPropertyValue(NameOf(LastName), value)
 			End Set
 		End Property
-		<NonPersistent>
+		<PersistentAlias("Concat(FirstName, ' ', LastName)")>
 		Public ReadOnly Property ContactName() As String
 			Get
 				Return String.Concat(FirstName, " ", LastName)


### PR DESCRIPTION
`PersistentAlias` attribute enables server-side sorting, filtering, groping operations and summary calculation. We should show customers how to use this attribute with calculated properties in the tutorial.